### PR TITLE
Add device type icon

### DIFF
--- a/intel-edison.svg
+++ b/intel-edison.svg
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 16.0.4, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1"
+	 id="svg2328" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://web.resource.org/cc/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:svg="http://www.w3.org/2000/svg" xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd" xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape" sodipodi:docname="aa.svg" sodipodi:docbase="C:\Documents and Settings\Alex Broersma.D2KY7761\Desktop" inkscape:version="0.45.1" sodipodi:version="0.32" inkscape:output_extension="org.inkscape.output.svg.inkscape"
+	 xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" width="616px" height="641px"
+	 viewBox="0 0 616 641" enable-background="new 0 0 616 641" xml:space="preserve">
+<sodipodi:namedview  inkscape:cy="131.76504" inkscape:cx="219.80302" inkscape:zoom="4.0618557" pagecolor="#ffffff" bordercolor="#666666" borderopacity="1.0" gridtolerance="10.0" guidetolerance="10.0" objecttolerance="10.0" id="base" inkscape:current-layer="svg2328" inkscape:window-y="-4" inkscape:window-x="-4" inkscape:pageopacity="0.0" inkscape:pageshadow="2" inkscape:window-width="1440" inkscape:window-height="844">
+	</sodipodi:namedview>
+<g>
+	<path id="path6" fill="#127CC1" d="M609.087,116.168C580.474-23.311,310.583-32.145,136.609,74.121v11.736
+		C310.354-3.826,556.89-3.253,579.325,125.228c7.558,42.564-16.252,86.831-58.943,112.303v33.332
+		C571.772,252.008,624.306,190.979,609.087,116.168 M292.728,360.373c-120.063,11.113-245.164-6.377-262.677-100.566
+		c-8.698-46.378,12.475-95.604,40.405-126.146V117.31C20.095,161.638-7.261,217.708,8.534,283.908
+		c20.144,84.958,127.503,133.047,291.406,117.033c64.897-6.266,149.826-27.232,208.765-59.762v-46.217
+		C455.143,327.042,366.551,353.544,292.728,360.373z"/>
+	<path id="path8" fill="#127CC1" d="M499.089,96.004h-31.473v140.805c0,16.538,7.896,30.918,31.473,33.199"/>
+	<path id="path10" fill="#127CC1" d="M124.134,147.462H92.658v91.966c0,16.542,7.898,30.922,31.476,33.202"/>
+	<rect id="rect12" x="92.659" y="100.283" fill="#127CC1" width="31.476" height="29.954"/>
+	<path id="path14" fill="#127CC1" d="M312.755,271.15c-25.52,0-36.279-17.803-36.279-35.374V113.633h31.131v33.829h23.576v25.33
+		h-23.576v61.1c0,7.187,3.436,11.128,10.871,11.128h12.705v26.13H312.755"/>
+	<path id="path16" fill="#127CC1" d="M395.509,171.255c-10.643,0-18.883,5.533-22.317,13.007c-2.061,4.505-2.746,7.929-3.086,13.467
+		h48.185C417.604,184.205,411.531,171.255,395.509,171.255 M370.105,219.062c0,16.033,10.064,27.836,27.691,27.836
+		c13.852,0,20.719-3.878,28.73-11.8l19.229,18.539c-12.362,12.205-25.296,19.622-48.187,19.622
+		c-29.872,0-58.487-16.371-58.487-64.067c0-40.79,24.949-63.836,57.8-63.836c33.307,0,52.42,26.984,52.42,62.413v11.296h-79.199"/>
+	<path id="path18" fill="#127CC1" d="M208.947,172.792c9.155,0,12.933,4.509,12.933,11.867v86.661h31.248v-86.774
+		c0-17.628-9.386-37.084-36.74-37.084H151.95v123.856h31.131v-98.526"/>
+	<text transform="matrix(1.0217 0 0 1 516.918 116.5898)" fill="#127CC1" font-family="'ArialMT'" font-size="28.8313">®</text>
+</g>
+<text transform="matrix(1 0 0 1 4.5498 611.1709)" fill="#127CC1" font-family="'Tahoma'" font-size="210">Edison</text>
+</svg>


### PR DESCRIPTION
In accordance with https://github.com/resin-io/resin-ui/issues/194 I want to simplify the device type icons management steps.
This PR only adds the files, doesn't require any special management, deployment or further actions from your side.
When we have all the icons in all the repos I'll organize their deployment.

Signed-off-by: Eugene Mirotin <eugene@resin.io>