### PR TITLE
Make sure / is mounted read-only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 Change log
 -----------
 
+* Mount the rootfs read-only [Michal]
 * Increase size of the resin initramfs image from 8192K to 16384K to accommodate for size increase due to x86 arch [Florin]
 * Switch to the kernel with the initramfs bundled in [Florin]
 * Update the meta-resin submodule to version v2.0.0-rc3 [Florin]

--- a/layers/meta-resin-edison/recipes-core/images/resin-image.bbappend
+++ b/layers/meta-resin-edison/recipes-core/images/resin-image.bbappend
@@ -69,3 +69,10 @@ build_hddimg_prepend_edison() {
 build_hddimg_append_edison() {
     cp -rL ${DEPLOY_DIR_IMAGE}/resin-image-edison.hddimg ${DEPLOY_DIR_IMAGE}/resin-edison/
 }
+
+# The Edison ships with its own /etc/fstab, which differs from the one
+# normally shipped with Poky. It requires a slightly different sed
+# expression to switch the root partition to read-only.
+read_only_rootfs_hook_append () {
+    sed -i -e '/^[#[:space:]]*rootfs/{s/nodev/ro,nodev/;s/\([[:space:]]*[[:digit:]]\)\([[:space:]]*\)[[:digit:]]$/\1\20/}' ${IMAGE_ROOTFS}/etc/fstab
+}


### PR DESCRIPTION
    The Edison ships with its own /etc/fstab, which differs from the one
    normally shipped with Poky. It requires a slightly different sed
    expression to switch the root partition to read-only.