### PR TITLE
Update meta-rust to morty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 Change log
 -----------
 
+* Update meta-rust to morty [Will]
 * Include meta-rust layer [Will]
 * Add meta-rust layer [Will]
 


### PR DESCRIPTION

This branch of meta-rust contains everything we need - cargo dependency fetching and the Rust 1.13 compiler that the jethro and krogoth branches don't. Combined with a set of backports in meta-resin this seems to build healthdog OK.
