### PR TITLE
modemmanager: Do not listen on ttyS*

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 Change log
 -----------
 
+* Do not let ModemManager take over ttyS* interfaces [Florin]
 * Add support for FUSE [Florin]
 
 # v2.7.8+rev2

--- a/layers/meta-resin-edison/recipes-connectivity/modemmanager/files/77-mm-tty-device-blacklist.rules
+++ b/layers/meta-resin-edison/recipes-connectivity/modemmanager/files/77-mm-tty-device-blacklist.rules
@@ -1,0 +1,3 @@
+ACTION!="add|change", GOTO="mm_tty_blacklist_end"
+SUBSYSTEM=="pci", DRIVERS=="8250_mid", ENV{ID_MM_DEVICE_IGNORE}="1"
+LABEL="mm_tty_blacklist_end"

--- a/layers/meta-resin-edison/recipes-connectivity/modemmanager/modemmanager_%.bbappend
+++ b/layers/meta-resin-edison/recipes-connectivity/modemmanager/modemmanager_%.bbappend
@@ -1,0 +1,7 @@
+FILESEXTRAPATHS_append := ":${THISDIR}/files"
+
+SRC_URI_append = " file://77-mm-tty-device-blacklist.rules"
+
+do_install_append() {
+    install -D -m 0644 ${WORKDIR}/77-mm-tty-device-blacklist.rules ${D}/lib/udev/rules.d/
+}


### PR DESCRIPTION
The Intel Edison does not have a modem attached to these interfaces
so we better not let ModemManager take them over.

Signed-off-by: Florin Sarbu <florin@resin.io>