### PR TITLE
packagegroup-edison.bb: Add bluez5-noinst-tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 Change log
 -----------
 
+* Add bluez5-noinst-tools to the rootfs for having a functional bluetooth [Florin]
 * Update the meta-edison-bsp submodule to f2740e29e74ebf5e4b0a07907db5cedcb673c9b5 (on pyro branch) [Florin]
 * Do not let ModemManager take over ttyS* interfaces [Florin]
 * Add support for FUSE [Florin]

--- a/layers/meta-resin-edison/recipes-core/packagegroups/packagegroup-edison.bb
+++ b/layers/meta-resin-edison/recipes-core/packagegroups/packagegroup-edison.bb
@@ -9,6 +9,7 @@ RDEPENDS_${PN} = "\
     u-boot \
     u-boot-fw-utils \
     bluetooth-rfkill-event \
+    bluez5-noinst-tools \
     sst-fw \
     mcu-fw-load \
     mcu-fw-bin \


### PR DESCRIPTION
We need the bluez5-noinst-tools package in the rootfs. This package adds
the btattach binary we need to have bluetooth functional on kernel 4.x

Signed-off-by: Florin Sarbu <florin@resin.io>